### PR TITLE
[codex] Use fast WiLoR fork by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ My fork is outdated now, and I am working to get it working with the newest veri
 pip install "hand-teleop @ git+https://github.com/joeclinton1/hand-teleop.git#egg=hand-teleop[wilor]"
 ```
 
+This extra installs WiLoR from my fork:
+
+```toml
+wilor-mini = { git = "https://github.com/Joeclinton1/WiLoR-mini", optional = true }
+```
+
+The fork ports upstream WiLoR's fast inference path into WiLoR-mini. CUDA WiLoR uses this path by default in `hand-teleop`, enabling fp16 inference and the upstream ViT depth-pruning block skip.
+
 > ✅ **Works well out of the box**
 > ⚠️ **Requires GPU with CUDA**
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ python main.py
 
 ---
 
+## LeRobot Integration
+
+The package also exposes `DualHandTracker` for integrations that need both hands from one webcam/model pass. In the `gem` branch of my LeRobot fork, use `--teleop.type=hand_teleop` to drive a GEM-compatible leader action from hand tracking.
+
+For a physical single GEM arm, use one hand:
+
+```bash
+lerobot-teleoperate --robot.type=gem --teleop.type=hand_teleop --teleop.hand=right
+```
+
+For the robot-arm viewer with two hands, use viewer-only bimanual mode:
+
+```bash
+lerobot-teleoperate --robot.type=gem --viewer.enabled=true --viewer.only=true --teleop.type=hand_teleop --teleop.hand=both
+```
+
+---
+
 ## Controls
 
 * `p` — Pause/resume

--- a/hand_teleop/__init__.py
+++ b/hand_teleop/__init__.py
@@ -1,0 +1,4 @@
+from hand_teleop.tracking.dual_tracker import DualHandTracker
+from hand_teleop.tracking.tracker import HandTracker
+
+__all__ = ["DualHandTracker", "HandTracker"]

--- a/hand_teleop/gripper_pose/gripper_pose_computer.py
+++ b/hand_teleop/gripper_pose/gripper_pose_computer.py
@@ -10,6 +10,7 @@ from hand_teleop.hand_pose.factory import (
     ModelName,
     create_estimator,
 )
+from hand_teleop.hand_pose.estimators.base import HandPoseEstimator
 from hand_teleop.hand_pose.types import TrackedHandKeypoints
 
 
@@ -26,8 +27,9 @@ class GripperPoseComputer:
         device: Optional[str] = None,
         model: ModelName = "wilor",
         hand: Literal["left", "right"] = "right",
+        estimator: Optional[HandPoseEstimator] = None,
     ):
-        self.estimator = create_estimator(model, device=device)
+        self.estimator = estimator or create_estimator(model, device=device)
         self.hand = hand
 
         self.initial_pose: Optional[GripperPose] = None

--- a/hand_teleop/hand_pose/estimators/wilor.py
+++ b/hand_teleop/hand_pose/estimators/wilor.py
@@ -1,6 +1,12 @@
+import os
+import sys
 from typing import Optional
 
 import numpy as np
+
+if sys.platform == "win32":
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
 from wilor_mini.pipelines.wilor_hand_pose3d_estimation_pipeline import (
     WiLorHandPose3dEstimationPipeline,
 )

--- a/hand_teleop/hand_pose/estimators/wilor.py
+++ b/hand_teleop/hand_pose/estimators/wilor.py
@@ -10,11 +10,15 @@ from hand_teleop.hand_pose.types import HandKeypointsPred, TrackedHandKeypoints
 
 
 class WiLorEstimator(HandPoseEstimator):
-    def __init__(self, device: Optional[str] = None):
+    def __init__(self, device: Optional[str] = None, fast: bool = True):
         import torch
+
+        actual_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        use_fast = fast and str(actual_device).startswith("cuda")
         self.pipe = WiLorHandPose3dEstimationPipeline(
-            device=device or ("cuda" if torch.cuda.is_available() else "cpu"),
-            dtype=torch.float16,
+            device=actual_device,
+            dtype=torch.float16 if use_fast else torch.float32,
+            fast=use_fast,
             verbose=False,
         )
 

--- a/hand_teleop/kinematics/kinematics.py
+++ b/hand_teleop/kinematics/kinematics.py
@@ -1,8 +1,12 @@
 # ruff: noqa: N806
 
 import os
+import sys
 
 import numpy as np
+
+if sys.platform == "win32":
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 try:
     import pinocchio as pin

--- a/hand_teleop/kinematics/kinematics.py
+++ b/hand_teleop/kinematics/kinematics.py
@@ -28,6 +28,7 @@ class RobotKinematics:
         self.data = self.model.createData()
         self.frame_id = self.model.getFrameId(frame_name)
         self.frame_name = frame_name
+        self.nq = self.model.nq
 
     # ---------- Forward kinematics ----------
     def fk(self, q, frame: str | None = None):

--- a/hand_teleop/tracking/dual_tracker.py
+++ b/hand_teleop/tracking/dual_tracker.py
@@ -20,6 +20,7 @@ from hand_teleop.tracking.kalman_filter import KalmanXYZ
 from hand_teleop.tracking.tracker import DEFAULT_CAM_T
 
 HandName = Literal["left", "right"]
+REALIGN_VISIBLE_SECONDS = 1.0
 
 
 @dataclass
@@ -30,6 +31,7 @@ class _TrackedHandState:
     initial_pose: Optional[GripperPose] = None
     base_pose: Optional[GripperPose] = None
     last_final_pose: Optional[GripperPose] = None
+    realign_visible_since: Optional[float] = None
 
 
 class DualHandPoseComputer:
@@ -111,6 +113,7 @@ class DualHandTracker:
         }
         self._lock = threading.Lock()
         self.tracking_paused = start_paused
+        self._realign_pending: set[HandName] = set()
 
         self._stop = threading.Event()
         self._listener = keyboard.Listener(on_press=self._on_press, on_release=self._on_release)
@@ -127,12 +130,18 @@ class DualHandTracker:
                 continue
 
             frame = cv2.flip(frame, 1)
-            if not self.tracking_paused:
+            abs_poses: dict[HandName, GripperPose] = {}
+            if not self.tracking_paused or self._realign_pending:
                 abs_poses = self.pose_computer.compute_absolute_poses(
                     frame,
                     self.focal_ratio * frame.shape[1],
                     self.cam_t,
                 )
+
+            if self._realign_pending:
+                self._update_realign(abs_poses)
+
+            if not self.tracking_paused:
                 for hand, abs_pose in abs_poses.items():
                     self._update_hand(hand, abs_pose)
 
@@ -151,7 +160,7 @@ class DualHandTracker:
                 )
                 cv2.putText(
                     frame,
-                    "Press 'p' to pause | Hold SPACE to realign",
+                    "Press 'p' to pause | Press SPACE to realign",
                     (10, frame.shape[0] - 10),
                     cv2.FONT_HERSHEY_SIMPLEX,
                     0.6,
@@ -160,6 +169,34 @@ class DualHandTracker:
                 )
                 cv2.imshow("dual-hand-teleop", frame)
                 cv2.waitKey(1)
+
+    def _update_realign(self, abs_poses: dict[HandName, GripperPose]) -> None:
+        now = time.perf_counter()
+        with self._lock:
+            for hand in tuple(self._realign_pending):
+                state = self._hands[hand]
+                abs_pose = abs_poses.get(hand)
+                if abs_pose is None:
+                    state.realign_visible_since = None
+                    continue
+
+                if state.realign_visible_since is None:
+                    state.realign_visible_since = now
+                    continue
+
+                if now - state.realign_visible_since < REALIGN_VISIBLE_SECONDS:
+                    continue
+
+                state.kf.reset()
+                state.kf_t = now
+                state.prev_rel_pose = GripperPose.zero()
+                state.initial_pose = abs_pose.copy()
+                state.base_pose = None
+                state.realign_visible_since = None
+                self._realign_pending.remove(hand)
+
+            if not self._realign_pending:
+                self.tracking_paused = False
 
     def _update_hand(self, hand: HandName, abs_pose: GripperPose) -> None:
         with self._lock:
@@ -186,13 +223,12 @@ class DualHandTracker:
 
     def _on_press(self, key):
         if key == keyboard.Key.space:
-            self._pause()
+            self._request_realign()
         elif key == keyboard.KeyCode.from_char("p"):
             self._resume() if self.tracking_paused else self._pause()
 
     def _on_release(self, key):
-        if key == keyboard.Key.space:
-            self._resume()
+        _ = key
 
     def _pause(self) -> None:
         self.tracking_paused = True
@@ -202,6 +238,7 @@ class DualHandTracker:
 
     def _resume(self) -> None:
         self.tracking_paused = False
+        self._realign_pending.clear()
         with self._lock:
             now = time.perf_counter()
             for state in self._hands.values():
@@ -210,6 +247,21 @@ class DualHandTracker:
                 state.prev_rel_pose = GripperPose.zero()
                 state.initial_pose = None
                 state.base_pose = None
+                state.realign_visible_since = None
+        self.pose_computer.reset()
+
+    def _request_realign(self) -> None:
+        self.tracking_paused = True
+        self._realign_pending = {"left", "right"}
+        with self._lock:
+            now = time.perf_counter()
+            for state in self._hands.values():
+                state.kf.reset()
+                state.kf_t = now
+                state.prev_rel_pose = GripperPose.zero()
+                state.initial_pose = None
+                state.base_pose = None
+                state.realign_visible_since = None
         self.pose_computer.reset()
 
     def _predict_only(self, hand: HandName) -> None:

--- a/hand_teleop/tracking/dual_tracker.py
+++ b/hand_teleop/tracking/dual_tracker.py
@@ -246,8 +246,15 @@ class DualHandTracker:
         if self.robot_kin is None:
             raise RuntimeError("robot_kin is not initialized. Pass a URDF to use this function.")
 
-        arm_joints_rad = np.radians(base_pose_joint[:5])
-        gripper_val = float(base_pose_joint[5])
+        arm_dof = self.robot_kin.nq
+        if len(base_pose_joint) < arm_dof + 1:
+            raise ValueError(
+                f"Expected at least {arm_dof + 1} base joint values for {self.robot_kin.urdf_path}, "
+                f"got {len(base_pose_joint)}."
+            )
+
+        arm_joints_rad = np.radians(base_pose_joint[:arm_dof])
+        gripper_val = float(base_pose_joint[arm_dof])
         base_pose = self.robot_kin.fk(arm_joints_rad)
         base_gripper_pose = GripperPose.from_matrix(base_pose, open_degree=gripper_val)
         final_gripper_pose = self.read_hand_state(hand, base_gripper_pose)

--- a/hand_teleop/tracking/dual_tracker.py
+++ b/hand_teleop/tracking/dual_tracker.py
@@ -1,0 +1,274 @@
+# ruff: noqa: N806 N803
+"""Dual-hand tracker using one camera stream and one model forward per frame."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import cv2
+import numpy as np
+from pynput import keyboard
+
+from hand_teleop.gripper_pose.gripper_pose import GripperPose
+from hand_teleop.gripper_pose.gripper_pose_computer import GripperPoseComputer
+from hand_teleop.hand_pose.factory import ModelName, create_estimator
+from hand_teleop.hand_pose.types import HandKeypointsPred
+from hand_teleop.tracking.kalman_filter import KalmanXYZ
+from hand_teleop.tracking.tracker import DEFAULT_CAM_T
+
+HandName = Literal["left", "right"]
+
+
+@dataclass
+class _TrackedHandState:
+    kf: KalmanXYZ
+    kf_t: float
+    prev_rel_pose: GripperPose
+    initial_pose: Optional[GripperPose] = None
+    base_pose: Optional[GripperPose] = None
+    last_final_pose: Optional[GripperPose] = None
+
+
+class DualHandPoseComputer:
+    """Computes left/right hand poses from a shared hand-pose estimator call."""
+
+    def __init__(self, device: Optional[str] = None, model: ModelName = "wilor"):
+        self.estimator = create_estimator(model, device=device)
+        self._pose_computer = GripperPoseComputer(device=device, model=model, estimator=self.estimator)
+
+        self.robot_axes_in_hand = self._pose_computer.robot_axes_in_hand
+        self.raw_abs_poses: dict[HandName, GripperPose] = {}
+
+    def reset(self, hand: HandName | None = None) -> None:
+        if hand is None:
+            self.raw_abs_poses.clear()
+        else:
+            self.raw_abs_poses.pop(hand, None)
+
+    def compute_absolute_poses(
+        self, frame: np.ndarray, focal_length: float, cam_t: np.ndarray
+    ) -> dict[HandName, GripperPose]:
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        preds = self.estimator(frame_rgb, focal_length)
+        poses: dict[HandName, GripperPose] = {}
+
+        for pred in preds:
+            hand = self._prediction_hand_after_frame_flip(pred)
+            if hand in poses:
+                continue
+            pose = self._pose_computer._compute_gripper_pose(pred.keypoints)
+            pose.change_basis(self.robot_axes_in_hand, cam_t)
+            poses[hand] = pose
+
+        self.raw_abs_poses = {hand: pose.copy() for hand, pose in poses.items()}
+        return poses
+
+    @staticmethod
+    def _prediction_hand_after_frame_flip(pred: HandKeypointsPred) -> HandName:
+        # The webcam frame is horizontally flipped before inference. Existing single-hand
+        # code compensates by selecting the opposite classifier label.
+        return "left" if pred.is_right else "right"
+
+
+class DualHandTracker:
+    def __init__(
+        self,
+        cam_idx: int = 0,
+        device: Optional[str] = None,
+        model: ModelName = "wilor",
+        show_viz: bool = False,
+        focal_ratio: float = 0.7,
+        cam_t: np.ndarray = DEFAULT_CAM_T,
+        urdf_path: Optional[str] = None,
+        frame_name: str = "gripper_link",
+        safe_range: Optional[dict[str, tuple[float, float]]] = None,
+        debug_mode: bool = False,
+        kf_dt: float = 1 / 30,
+        kf_q: float = 5e-3,
+        kf_r: float = 5e-3,
+        start_paused: bool = False,
+    ):
+        self.focal_ratio = focal_ratio
+        self.show_viz = show_viz
+        self.cam_t = cam_t
+        self.debug_mode = debug_mode
+        self.safe_range = safe_range
+        self._max_jump_rate = 2
+
+        self.cap = cv2.VideoCapture(cam_idx)
+        self.pose_computer = DualHandPoseComputer(device=device, model=model)
+        self.robot_kin = (
+            self._make_robot_kinematics(urdf_path, frame_name) if urdf_path is not None else None
+        )
+
+        now = time.perf_counter()
+        self._hands: dict[HandName, _TrackedHandState] = {
+            "left": _TrackedHandState(KalmanXYZ(dt=kf_dt, q=kf_q, r=kf_r), now, GripperPose.zero()),
+            "right": _TrackedHandState(KalmanXYZ(dt=kf_dt, q=kf_q, r=kf_r), now, GripperPose.zero()),
+        }
+        self._lock = threading.Lock()
+        self.tracking_paused = start_paused
+
+        self._stop = threading.Event()
+        self._listener = keyboard.Listener(on_press=self._on_press, on_release=self._on_release)
+        self._listener.start()
+        threading.Thread(target=self._capture_loop, daemon=True).start()
+
+    def _capture_loop(self) -> None:
+        ema_fps = 60.0
+        while not self._stop.is_set():
+            loop_start = time.perf_counter()
+            ok, frame = self.cap.read()
+            if not ok:
+                time.sleep(0.001)
+                continue
+
+            frame = cv2.flip(frame, 1)
+            if not self.tracking_paused:
+                abs_poses = self.pose_computer.compute_absolute_poses(
+                    frame,
+                    self.focal_ratio * frame.shape[1],
+                    self.cam_t,
+                )
+                for hand, abs_pose in abs_poses.items():
+                    self._update_hand(hand, abs_pose)
+
+            if self.show_viz:
+                frame_time = time.perf_counter() - loop_start
+                if frame_time > 1e-6:
+                    ema_fps = 0.9 * ema_fps + 0.1 * (1.0 / frame_time)
+                cv2.putText(
+                    frame,
+                    f"FPS: {ema_fps:.1f}",
+                    (10, 30),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    1.0,
+                    (0, 255, 0),
+                    2,
+                )
+                cv2.putText(
+                    frame,
+                    "Press 'p' to pause | Hold SPACE to realign",
+                    (10, frame.shape[0] - 10),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.6,
+                    (100, 100, 100),
+                    1,
+                )
+                cv2.imshow("dual-hand-teleop", frame)
+                cv2.waitKey(1)
+
+    def _update_hand(self, hand: HandName, abs_pose: GripperPose) -> None:
+        with self._lock:
+            state = self._hands[hand]
+            if state.initial_pose is None:
+                state.initial_pose = abs_pose.copy()
+
+            rel_pose = abs_pose.copy()
+            rel_pose.inverse_transform_pose(state.initial_pose.rot, state.initial_pose.pos)
+
+            now = time.perf_counter()
+            dt = now - state.kf_t
+            jump = np.linalg.norm(rel_pose.pos - state.prev_rel_pose.pos)
+            max_jump = self._max_jump_rate * max(dt, 1e-4)
+            if jump > max_jump:
+                direction = rel_pose.pos - state.prev_rel_pose.pos
+                rel_pose.pos = state.prev_rel_pose.pos + direction / jump * max_jump
+
+            if dt > 0.0:
+                state.kf.predict(dt)
+            state.kf.update(rel_pose.pos)
+            state.kf_t = now
+            state.prev_rel_pose = rel_pose.copy()
+
+    def _on_press(self, key):
+        if key == keyboard.Key.space:
+            self._pause()
+        elif key == keyboard.KeyCode.from_char("p"):
+            self._resume() if self.tracking_paused else self._pause()
+
+    def _on_release(self, key):
+        if key == keyboard.Key.space:
+            self._resume()
+
+    def _pause(self) -> None:
+        self.tracking_paused = True
+        with self._lock:
+            for state in self._hands.values():
+                state.kf.x[3:] = 0.0
+
+    def _resume(self) -> None:
+        self.tracking_paused = False
+        with self._lock:
+            now = time.perf_counter()
+            for state in self._hands.values():
+                state.kf.reset()
+                state.kf_t = now
+                state.prev_rel_pose = GripperPose.zero()
+                state.initial_pose = None
+                state.base_pose = None
+        self.pose_computer.reset()
+
+    def _predict_only(self, hand: HandName) -> None:
+        if self.tracking_paused:
+            return
+        state = self._hands[hand]
+        now = time.perf_counter()
+        dt = now - state.kf_t
+        if dt > 0.0:
+            state.kf.predict(dt)
+            state.kf_t = now
+
+    def predict_pose(self, hand: HandName) -> GripperPose:
+        with self._lock:
+            self._predict_only(hand)
+            state = self._hands[hand]
+            pose = state.prev_rel_pose.copy()
+            pose.pos = state.kf.x[:3]
+            return pose
+
+    def read_hand_state(self, hand: HandName, base_pose: GripperPose) -> GripperPose:
+        rel = self.predict_pose(hand)
+        with self._lock:
+            state = self._hands[hand]
+            if state.base_pose is None:
+                state.base_pose = base_pose.copy()
+            final_pose = state.base_pose.copy()
+            final_pose.transform_pose(rel.rot, rel.pos)
+            final_pose.open_degree = rel.open_degree
+            state.last_final_pose = final_pose.copy()
+            return final_pose
+
+    def read_hand_state_joint(self, hand: HandName, base_pose_joint: np.ndarray) -> np.ndarray:
+        if self.robot_kin is None:
+            raise RuntimeError("robot_kin is not initialized. Pass a URDF to use this function.")
+
+        arm_joints_rad = np.radians(base_pose_joint[:5])
+        gripper_val = float(base_pose_joint[5])
+        base_pose = self.robot_kin.fk(arm_joints_rad)
+        base_gripper_pose = GripperPose.from_matrix(base_pose, open_degree=gripper_val)
+        final_gripper_pose = self.read_hand_state(hand, base_gripper_pose)
+
+        if self.safe_range:
+            final_gripper_pose.clip(self.safe_range)
+
+        new_arm_joints_rad = self.robot_kin.ik(
+            arm_joints_rad.copy(), final_gripper_pose.to_matrix(), max_iters=6
+        )
+        new_arm_joints_deg = np.degrees(new_arm_joints_rad)
+        return np.append(new_arm_joints_deg, final_gripper_pose.open_degree).astype(np.float32)
+
+    def close(self) -> None:
+        self._stop.set()
+        self._listener.stop()
+        self.cap.release()
+        cv2.destroyAllWindows()
+
+    @staticmethod
+    def _make_robot_kinematics(urdf_path: str, frame_name: str):
+        from hand_teleop.kinematics.kinematics import RobotKinematics
+
+        return RobotKinematics(urdf_path=urdf_path, frame_name=frame_name)

--- a/hand_teleop/tracking/tracker.py
+++ b/hand_teleop/tracking/tracker.py
@@ -303,9 +303,16 @@ class HandTracker:
                 "robot_kin is not initialized. Pass a URDF to use this function."
             )
 
-        # Convert base joint angles to radians for kinematics
-        arm_joints_rad = np.radians(base_pose_joint[:5])
-        gripper_val = float(base_pose_joint[5])  # gripper remains in degrees
+        arm_dof = self.robot_kin.nq
+        if len(base_pose_joint) < arm_dof + 1:
+            raise ValueError(
+                f"Expected at least {arm_dof + 1} base joint values for {self.robot_kin.urdf_path}, "
+                f"got {len(base_pose_joint)}."
+            )
+
+        # Convert base joint angles to radians for kinematics.
+        arm_joints_rad = np.radians(base_pose_joint[:arm_dof])
+        gripper_val = float(base_pose_joint[arm_dof])  # gripper remains in degrees
 
         # Forward kinematics in radians
         base_pose = self.robot_kin.fk(arm_joints_rad)

--- a/hand_teleop/tracking/tracker.py
+++ b/hand_teleop/tracking/tracker.py
@@ -20,7 +20,6 @@ from hand_teleop.gripper_pose.gripper_pose import GripperPose
 from hand_teleop.gripper_pose.gripper_pose_computer import GripperPoseComputer
 from hand_teleop.gripper_pose.gripper_pose_visualizer import GripperPoseVisualizer
 from hand_teleop.hand_pose.factory import ModelName
-from hand_teleop.kinematics.kinematics import RobotKinematics
 from hand_teleop.tracking.kalman_filter import KalmanXYZ
 
 DEFAULT_CAM_T = np.array([0, -0.24, 0.6], dtype=np.float32)
@@ -72,7 +71,7 @@ class HandTracker:
         )
 
         self.robot_kin = (
-            RobotKinematics(urdf_path=urdf_path, frame_name=frame_name)
+            self._make_robot_kinematics(urdf_path, frame_name)
             if urdf_path is not None
             else None
         )
@@ -241,6 +240,12 @@ class HandTracker:
         self._scroll_open = float(
             np.clip(self._scroll_open + dy * self.scroll_scale * 90, 0.0, 90.0)
         )
+
+    @staticmethod
+    def _make_robot_kinematics(urdf_path: str, frame_name: str):
+        from hand_teleop.kinematics.kinematics import RobotKinematics
+
+        return RobotKinematics(urdf_path=urdf_path, frame_name=frame_name)
 
     # ------------------------------------------------------------------
     # Internal helper – predict only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "3.10.*"
+python = ">=3.10,<3.13"
 numpy = "^1.23.0"
 pydantic = "^1.10.0"
 pynput = "^1.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-numpy = "^1.23.0"
-pydantic = "^1.10.0"
+numpy = ">=1.23,<3"
 pynput = "^1.7"
 opencv-python = "*"
 


### PR DESCRIPTION
## Summary

- Use the Joeclinton1/WiLoR-mini fork's fast CUDA inference path by default in the WiLoR estimator.
- Document that the `wilor` extra installs the fork and uses fp16 plus upstream ViT depth pruning.

## Validation

- Installed the local WiLoR-mini fork editable into the `hand-teleop` Conda environment.
- Ran `python -m compileall wilor_mini` in the fork.
- Ran `python -m compileall hand_teleop` in this repo.
- Ran `python -m pip check`.
- Benchmarked WiLoR baseline vs fast mode on the local RTX 3070 Ti Laptop GPU.

## Notes

The WiLoR-mini fork update was pushed directly to `Joeclinton1/WiLoR-mini@main` because `hand-teleop` already depends on that fork URL.